### PR TITLE
fix(musou.tw): fix json syntax error

### DIFF
--- a/musou.tw/support.json
+++ b/musou.tw/support.json
@@ -3,7 +3,7 @@
     "icon": "https://watchout-tw.github.io/musou-aux/musou.tw/emoji/people.png",
     "title": "群眾支持",
     "join": "https://watchout-tw.github.io/musou-aux/musou.tw/join.png",
-    "thanks": "https://watchout-tw.github.io/musou-aux/musou.tw/thanks.png",
+    "thanks": "https://watchout-tw.github.io/musou-aux/musou.tw/thanks.png"
   },
   "enterprises": {
     "icon": "https://watchout-tw.github.io/musou-aux/musou.tw/emoji/castle.png",


### PR DESCRIPTION
@chihaoyo GitHub 會在 header 把 json 標示成 `plain/text` ，而這個失誤會讓後續 `JSON.parse` 出現 error 且沒有其他 module 輔助的話不容易 debug